### PR TITLE
Snafu removed in order to limit the dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "snafu",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["api", "github", "tool"]
 [dependencies]
 serde_json = "1.0.79"
 serde_yaml = "0.8.23"
-snafu = "0.7.0"
 hyper-tls = "0.5.0"
 rpassword = "6.0.1"
 rprompt = "1.0.5"

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,0 +1,191 @@
+use crate::error::Error;
+use crate::octomate::Context;
+use octocrab::models::{gists::Gist, issues::Issue, teams::Team, Label};
+use octocrab::Octocrab;
+use paris::info;
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum Command {
+    CreateLabel(CreateLabelOptions),
+    CreateIssue(CreateIssueOptions),
+    CreateTeam(CreateTeamOptions),
+    CreateGist(CreateGistOptions),
+}
+
+impl Command {
+    pub async fn run(
+        &self,
+        octocrab: &Octocrab,
+        ctx: &Context<'_>,
+    ) -> Vec<Result<Response, Error>> {
+        info!("run: {:?}", self);
+        match self {
+            Self::CreateLabel(options) => options.run(octocrab, ctx).await,
+            Self::CreateIssue(options) => options.run(octocrab, ctx).await,
+            Self::CreateTeam(options) => options.run(octocrab, ctx).await,
+            Self::CreateGist(options) => options.run(octocrab, ctx).await,
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+pub struct CreateGistOptions {
+    pub title: String,
+    pub content: String,
+    pub description: Option<String>,
+    pub public: Option<bool>,
+}
+
+impl CreateGistOptions {
+    pub async fn run(
+        &self,
+        octocrab: &Octocrab,
+        _ctx: &Context<'_>,
+    ) -> Vec<Result<Response, Error>> {
+        let gist_res = octocrab
+            .gists()
+            .create()
+            .file(&self.title, &self.content)
+            .description(&self.description.clone().unwrap_or_default())
+            .public(self.public.unwrap_or(false))
+            .send()
+            .await;
+
+        match gist_res {
+            Ok(gist) => vec![Ok(Response::CreateGist(gist))],
+            Err(err) => vec![Err(Error::from(err))],
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+pub struct CreateTeamOptions {
+    pub name: String,
+    pub description: Option<String>,
+    pub owner: String,
+    pub maintainers: Option<Vec<String>>,
+}
+
+impl CreateTeamOptions {
+    pub async fn run(
+        &self,
+        octocrab: &Octocrab,
+        ctx: &Context<'_>,
+    ) -> Vec<Result<Response, Error>> {
+        let team = match ctx.job {
+            None => Ok(Response::None),
+            Some(job) => {
+                let on_repositories = &job.on_repositories;
+                let repo_names: &Vec<String> = &on_repositories
+                    .iter()
+                    .map(|repository| repository.name.clone())
+                    .collect();
+
+                let description = self.description.clone().unwrap_or_default();
+                let maintainers = self.maintainers.clone().unwrap_or_default();
+
+                let team_res = octocrab
+                    .teams(&self.owner)
+                    .create(&self.name)
+                    .description(&description)
+                    .maintainers(&maintainers)
+                    .repo_names(&repo_names)
+                    .send()
+                    .await;
+
+                match team_res {
+                    Ok(team) => Ok(Response::CreateTeam(team)),
+                    Err(err) => Err(Error::from(err)),
+                }
+            }
+        };
+        vec![team]
+    }
+}
+
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+pub struct CreateIssueOptions {
+    pub title: String,
+    pub body: String,
+    pub milestone: Option<u64>,
+    pub assignees: Option<Vec<String>>,
+    pub labels: Option<Vec<String>>,
+}
+
+impl CreateIssueOptions {
+    pub async fn run(
+        &self,
+        octocrab: &Octocrab,
+        ctx: &Context<'_>,
+    ) -> Vec<Result<Response, Error>> {
+        match ctx.job {
+            None => vec![Ok(Response::None)],
+            Some(job) => {
+                let on_repositories = &job.on_repositories;
+                let statements = on_repositories.iter().map(|repository| async move {
+                    let milestone = self.milestone.unwrap_or_default();
+                    let assignees = self.assignees.clone().unwrap_or_default();
+                    let labels = self.labels.clone().unwrap_or_default();
+
+                    let issue = octocrab
+                        .issues(&repository.owner, &repository.name)
+                        .create(&self.title)
+                        .body(&self.body)
+                        .milestone(milestone)
+                        .assignees(assignees)
+                        .labels(labels)
+                        .send()
+                        .await?;
+
+                    Ok(Response::CreateIssue(issue))
+                });
+
+                let issues: Vec<Result<Response, Error>> =
+                    futures::future::join_all(statements).await;
+                issues
+            }
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+pub struct CreateLabelOptions {
+    pub name: String,
+    pub color: String,
+    pub description: String,
+}
+
+impl CreateLabelOptions {
+    pub async fn run(
+        &self,
+        octocrab: &Octocrab,
+        ctx: &Context<'_>,
+    ) -> Vec<Result<Response, Error>> {
+        match ctx.job {
+            None => vec![Ok(Response::None)],
+            Some(job) => {
+                let on_repositories = &job.on_repositories;
+                let statements = on_repositories.iter().map(|repository| async move {
+                    let label = octocrab
+                        .issues(&repository.owner, &repository.name)
+                        .create_label(&self.name, &self.color, &self.description)
+                        .await?;
+                    Ok(Response::CreateLabel(label))
+                });
+                let labels: Vec<Result<Response, Error>> =
+                    futures::future::join_all(statements).await;
+                labels
+            }
+        }
+    }
+}
+
+pub enum Response {
+    CreateLabel(Label),
+    CreateIssue(Issue),
+    CreateTeam(Team),
+    CreateGist(Gist),
+    None,
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,31 @@
+#[derive(Debug)]
+pub enum Error {
+    IO(tokio::io::Error),
+    SerdeJson(serde_json::Error),
+    SerdeYaml(serde_yaml::Error),
+    Octocrab(octocrab::Error),
+}
+
+impl From<tokio::io::Error> for Error {
+    fn from(err: tokio::io::Error) -> Self {
+        Error::IO(err)
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(err: serde_json::Error) -> Self {
+        Error::SerdeJson(err)
+    }
+}
+
+impl From<serde_yaml::Error> for Error {
+    fn from(err: serde_yaml::Error) -> Self {
+        Error::SerdeYaml(err)
+    }
+}
+
+impl From<octocrab::Error> for Error {
+    fn from(err: octocrab::Error) -> Self {
+        Error::Octocrab(err)
+    }
+}

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,0 +1,8 @@
+use crate::error::Error;
+use std::path::Path;
+use tokio::fs;
+
+pub async fn read_file(path: impl AsRef<Path>) -> Result<Vec<u8>, Error> {
+    let bytes = fs::read(&path).await?;
+    Ok(bytes)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,400 +1,15 @@
-use clap::Parser;
-use octocrab::Octocrab;
-use paris::{info, Logger};
-use serde::Deserialize;
-use snafu::{ResultExt, Snafu};
-use std::{path::Path, sync::Arc};
-use tokio::fs;
+pub mod command;
+pub mod error;
+pub mod io;
+pub mod octomate;
+pub mod options;
 
-#[derive(Debug, Snafu)]
-pub enum Error {
-    #[snafu(display("Could not read file {path}"))]
-    IO {
-        source: tokio::io::Error,
-        path: String,
-    },
-    #[snafu(display("SerdeJson error: {source}"))]
-    SerdeJson { source: serde_json::Error },
-    #[snafu(display("SerdeYaml error: {source}"))]
-    SerdeYaml { source: serde_yaml::Error },
-    #[snafu(display("Octocrab error: {source}"))]
-    Octocrab { source: octocrab::Error },
-}
-
-#[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
-pub struct Options {
-    #[clap(long, help = "The batch file to run")]
-    pub batch_file: String,
-}
-
-async fn read_file(path: impl AsRef<Path>) -> Result<Vec<u8>, Error> {
-    let bytes = fs::read(&path).await.context(IOSnafu {
-        path: String::from(path.as_ref().to_str().unwrap_or_default()),
-    })?;
-    Ok(bytes)
-}
-
-#[derive(Debug)]
-pub struct Context<'a> {
-    pub batch: &'a Batch,
-    pub job: Option<&'a Job>,
-    pub step: Option<&'a Step>,
-}
-
-impl<'a> Context<'a> {
-    pub fn new(batch: &'a Batch, job: Option<&'a Job>, step: Option<&'a Step>) -> Self {
-        Self { batch, job, step }
-    }
-
-    pub fn update_from_job(&self, job: &'a Job) -> Self {
-        Self {
-            batch: self.batch,
-            job: Some(job),
-            step: self.step,
-        }
-    }
-
-    pub fn update_from_step(&self, step: &'a Step) -> Self {
-        Self {
-            batch: self.batch,
-            job: self.job,
-            step: Some(step),
-        }
-    }
-}
-
-impl<'a> From<&Context<'a>> for Context<'a> {
-    fn from(ctx: &Context<'a>) -> Self {
-        Self {
-            batch: ctx.batch,
-            job: ctx.job,
-            step: ctx.step,
-        }
-    }
-}
-
-#[derive(Deserialize, Debug, Clone, PartialEq)]
-pub struct Batch {
-    pub version: String,
-    pub name: Option<String>,
-    pub jobs: Vec<Job>,
-}
-
-type BatchResult<Output, Err> = Vec<Vec<StepResult<Output, Err>>>;
-
-impl Batch {
-    pub async fn run(&self, octocrab: &Octocrab) -> BatchResult<command::Response, Error> {
-        println!();
-        info!(
-            "Running batch: {} with version specs: {}",
-            &self.name.clone().unwrap_or("UNAMED".to_string()),
-            &self.version,
-        );
-        let jobs = &self.jobs;
-        let jobs_iter = jobs
-            .iter()
-            .map(|job| async move { job.run(octocrab, &Context::new(self, None, None)).await });
-        futures::future::join_all(jobs_iter).await
-    }
-}
-
-impl TryFrom<&[u8]> for Batch {
-    type Error = Error;
-
-    fn try_from(batch_file: &[u8]) -> Result<Self, Self::Error> {
-        let batch = serde_yaml::from_slice(&batch_file).context(SerdeYamlSnafu)?;
-        Ok(batch)
-    }
-}
-
-#[derive(Deserialize, Debug, Clone, Default, PartialEq)]
-#[serde(rename_all = "kebab-case")]
-pub struct Job {
-    pub name: Option<String>,
-    pub on_repositories: Vec<Repository>,
-    pub steps: Vec<Step>,
-}
-
-impl Job {
-    pub async fn run(
-        &self,
-        octocrab: &Octocrab,
-        ctx: &Context<'_>,
-    ) -> Vec<StepResult<command::Response, Error>> {
-        info!(
-            "job: {}",
-            &self.name.clone().unwrap_or("UNAMED".to_string())
-        );
-        let steps = &self.steps;
-        let steps_iter = steps
-            .iter()
-            .map(|step| async move { step.run(octocrab, &ctx.update_from_job(self)).await });
-        futures::future::join_all(steps_iter).await
-    }
-}
-
-#[derive(Deserialize, Debug, Clone, PartialEq)]
-pub struct Repository {
-    pub owner: String,
-    pub name: String,
-}
-
-#[derive(Deserialize, Debug, Clone, Default, PartialEq)]
-pub struct Step {
-    pub name: Option<String>,
-    pub runs: Vec<command::Command>,
-}
-
-type StepResult<Output, Err> = Vec<Vec<Result<Output, Err>>>;
-
-impl Step {
-    pub async fn run(
-        &self,
-        octocrab: &Octocrab,
-        ctx: &Context<'_>,
-    ) -> StepResult<command::Response, Error> {
-        info!(
-            "step: {}",
-            &self.name.clone().unwrap_or("UNAMED".to_string())
-        );
-        let runs = &self.runs;
-        let runs_iter = runs
-            .iter()
-            .map(|command| async move { command.run(octocrab, &ctx.update_from_step(self)).await });
-        futures::future::join_all(runs_iter).await
-    }
-}
-
-pub mod command {
-    use super::{info, Context, Error, Octocrab};
-    use crate::OctocrabSnafu;
-    use octocrab::models::{gists::Gist, issues::Issue, teams::Team, Label};
-    use serde::Deserialize;
-    use snafu::ResultExt;
-
-    #[derive(Deserialize, Debug, Clone, PartialEq)]
-    #[serde(rename_all = "kebab-case")]
-    pub enum Command {
-        CreateLabel(CreateLabelOptions),
-        CreateIssue(CreateIssueOptions),
-        CreateTeam(CreateTeamOptions),
-        CreateGist(CreateGistOptions),
-    }
-
-    impl Command {
-        pub async fn run(
-            &self,
-            octocrab: &Octocrab,
-            ctx: &Context<'_>,
-        ) -> Vec<Result<Response, Error>> {
-            info!("run: {:?}", self);
-            match self {
-                Self::CreateLabel(options) => options.run(octocrab, ctx).await,
-                Self::CreateIssue(options) => options.run(octocrab, ctx).await,
-                Self::CreateTeam(options) => options.run(octocrab, ctx).await,
-                Self::CreateGist(options) => options.run(octocrab, ctx).await,
-            }
-        }
-    }
-
-    #[derive(Deserialize, Debug, Clone, PartialEq)]
-    pub struct CreateGistOptions {
-        pub title: String,
-        pub content: String,
-        pub description: Option<String>,
-        pub public: Option<bool>,
-    }
-
-    impl CreateGistOptions {
-        pub async fn run(
-            &self,
-            octocrab: &Octocrab,
-            _ctx: &Context<'_>,
-        ) -> Vec<Result<Response, Error>> {
-            let gist_res = octocrab
-                .gists()
-                .create()
-                .file(&self.title, &self.content)
-                .description(&self.description.clone().unwrap_or_default())
-                .public(self.public.unwrap_or(false))
-                .send()
-                .await
-                .context(OctocrabSnafu);
-
-            match gist_res {
-                Ok(gist) => vec![Ok(Response::CreateGist(gist))],
-                Err(err) => vec![Err(err)],
-            }
-        }
-    }
-
-    #[derive(Deserialize, Debug, Clone, PartialEq)]
-    pub struct CreateTeamOptions {
-        pub name: String,
-        pub description: Option<String>,
-        pub owner: String,
-        pub maintainers: Option<Vec<String>>,
-    }
-
-    impl CreateTeamOptions {
-        pub async fn run(
-            &self,
-            octocrab: &Octocrab,
-            ctx: &Context<'_>,
-        ) -> Vec<Result<Response, Error>> {
-            let team = match ctx.job {
-                None => Ok(Response::None),
-                Some(job) => {
-                    let on_repositories = &job.on_repositories;
-                    let repo_names: &Vec<String> = &on_repositories
-                        .iter()
-                        .map(|repository| repository.name.clone())
-                        .collect();
-
-                    let description = self.description.clone().unwrap_or_default();
-                    let maintainers = self.maintainers.clone().unwrap_or_default();
-
-                    let team_res = octocrab
-                        .teams(&self.owner)
-                        .create(&self.name)
-                        .description(&description)
-                        .maintainers(&maintainers)
-                        .repo_names(&repo_names)
-                        .send()
-                        .await
-                        .context(OctocrabSnafu);
-
-                    match team_res {
-                        Ok(team) => Ok(Response::CreateTeam(team)),
-                        Err(err) => Err(err),
-                    }
-                }
-            };
-            vec![team]
-        }
-    }
-
-    #[derive(Deserialize, Debug, Clone, PartialEq)]
-    pub struct CreateIssueOptions {
-        pub title: String,
-        pub body: String,
-        pub milestone: Option<u64>,
-        pub assignees: Option<Vec<String>>,
-        pub labels: Option<Vec<String>>,
-    }
-
-    impl CreateIssueOptions {
-        pub async fn run(
-            &self,
-            octocrab: &Octocrab,
-            ctx: &Context<'_>,
-        ) -> Vec<Result<Response, Error>> {
-            match ctx.job {
-                None => vec![Ok(Response::None)],
-                Some(job) => {
-                    let on_repositories = &job.on_repositories;
-                    let statements = on_repositories.iter().map(|repository| async move {
-                        let milestone = self.milestone.unwrap_or_default();
-                        let assignees = self.assignees.clone().unwrap_or_default();
-                        let labels = self.labels.clone().unwrap_or_default();
-
-                        let issue = octocrab
-                            .issues(&repository.owner, &repository.name)
-                            .create(&self.title)
-                            .body(&self.body)
-                            .milestone(milestone)
-                            .assignees(assignees)
-                            .labels(labels)
-                            .send()
-                            .await
-                            .context(OctocrabSnafu)?;
-
-                        Ok(Response::CreateIssue(issue))
-                    });
-
-                    let issues: Vec<Result<Response, Error>> =
-                        futures::future::join_all(statements).await;
-                    issues
-                }
-            }
-        }
-    }
-
-    #[derive(Deserialize, Debug, Clone, PartialEq)]
-    pub struct CreateLabelOptions {
-        pub name: String,
-        pub color: String,
-        pub description: String,
-    }
-
-    impl CreateLabelOptions {
-        pub async fn run(
-            &self,
-            octocrab: &Octocrab,
-            ctx: &Context<'_>,
-        ) -> Vec<Result<Response, Error>> {
-            match ctx.job {
-                None => vec![Ok(Response::None)],
-                Some(job) => {
-                    let on_repositories = &job.on_repositories;
-                    let statements = on_repositories.iter().map(|repository| async move {
-                        let label = octocrab
-                            .issues(&repository.owner, &repository.name)
-                            .create_label(&self.name, &self.color, &self.description)
-                            .await
-                            .context(OctocrabSnafu)?;
-                        Ok(Response::CreateLabel(label))
-                    });
-                    let labels: Vec<Result<Response, Error>> =
-                        futures::future::join_all(statements).await;
-                    labels
-                }
-            }
-        }
-    }
-
-    pub enum Response {
-        CreateLabel(Label),
-        CreateIssue(Issue),
-        CreateTeam(Team),
-        CreateGist(Gist),
-        None,
-    }
-}
-
-struct Octomate {
-    octocrab: Arc<Octocrab>,
-}
-
-impl Octomate {
-    async fn new(personal_token: impl Into<String>) -> Result<Self, Error> {
-        let octocrab = octocrab::Octocrab::builder()
-            .personal_token(personal_token.into())
-            .build()
-            .context(OctocrabSnafu)?;
-        Ok(Self {
-            octocrab: Arc::new(octocrab),
-        })
-    }
-
-    async fn run_batch(&self, batch: &Batch) -> BatchResult<command::Response, Error> {
-        batch.run(&self.octocrab).await
-    }
-
-    async fn run_batch_from_file(
-        &self,
-        filepath: impl AsRef<Path>,
-    ) -> Result<BatchResult<command::Response, Error>, Error> {
-        let bytes = read_file(filepath).await?;
-        let batch = Batch::try_from(bytes.as_slice())?;
-        Ok(self.run_batch(&batch).await)
-    }
-}
+use crate::options::Options;
+use paris::Logger;
 
 #[tokio::main]
 async fn main() {
-    let options = Options::parse();
+    let options = Options::from_cli();
     let mut logger = Logger::new();
 
     let personal_token =
@@ -402,7 +17,7 @@ async fn main() {
             .expect("You need to enter a valid personal access token");
 
     logger.loading("Authenticate to github in progress");
-    let octomate = Octomate::new(personal_token)
+    let octomate = octomate::Octomate::new(personal_token)
         .await
         .expect("Unable to init octocrab");
     logger
@@ -468,20 +83,20 @@ jobs:
        "#
         .as_bytes();
 
-        let batch = Batch::try_from(batch).unwrap();
+        let batch = octomate::Batch::try_from(batch).unwrap();
 
         assert_eq!(
             batch,
-            Batch {
+            octomate::Batch {
                 version: "1.0".to_owned(),
                 name: Some("Test".to_owned()),
-                jobs: vec![Job {
+                jobs: vec![octomate::Job {
                     name: Some("Perform some basics things for some repos".to_owned()),
-                    on_repositories: vec![Repository {
+                    on_repositories: vec![octomate::Repository {
                         owner: "me".to_owned(),
                         name: "repo1".to_owned(),
                     }],
-                    steps: vec![Step {
+                    steps: vec![octomate::Step {
                         name: Some("Hello world!".to_owned()),
                         runs: vec![command::Command::CreateLabel(command::CreateLabelOptions {
                             name: "bug".to_owned(),

--- a/src/octomate.rs
+++ b/src/octomate.rs
@@ -1,0 +1,167 @@
+use crate::command;
+use crate::error::Error;
+use crate::io;
+use octocrab::Octocrab;
+use paris::info;
+use serde::Deserialize;
+use std::path::Path;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct Context<'a> {
+    pub batch: &'a Batch,
+    pub job: Option<&'a Job>,
+    pub step: Option<&'a Step>,
+}
+
+impl<'a> Context<'a> {
+    pub fn new(batch: &'a Batch, job: Option<&'a Job>, step: Option<&'a Step>) -> Self {
+        Self { batch, job, step }
+    }
+
+    pub fn update_from_job(&self, job: &'a Job) -> Self {
+        Self {
+            batch: self.batch,
+            job: Some(job),
+            step: self.step,
+        }
+    }
+
+    pub fn update_from_step(&self, step: &'a Step) -> Self {
+        Self {
+            batch: self.batch,
+            job: self.job,
+            step: Some(step),
+        }
+    }
+}
+
+impl<'a> From<&Context<'a>> for Context<'a> {
+    fn from(ctx: &Context<'a>) -> Self {
+        Self {
+            batch: ctx.batch,
+            job: ctx.job,
+            step: ctx.step,
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+pub struct Batch {
+    pub version: String,
+    pub name: Option<String>,
+    pub jobs: Vec<Job>,
+}
+
+type BatchResult<Output, Err> = Vec<Vec<StepResult<Output, Err>>>;
+
+impl Batch {
+    pub async fn run(&self, octocrab: &Octocrab) -> BatchResult<command::Response, Error> {
+        println!();
+        info!(
+            "Running batch: {} with version specs: {}",
+            &self.name.clone().unwrap_or("UNAMED".to_string()),
+            &self.version,
+        );
+        let jobs = &self.jobs;
+        let jobs_iter = jobs
+            .iter()
+            .map(|job| async move { job.run(octocrab, &Context::new(self, None, None)).await });
+        futures::future::join_all(jobs_iter).await
+    }
+}
+
+impl TryFrom<&[u8]> for Batch {
+    type Error = Error;
+
+    fn try_from(batch_file: &[u8]) -> Result<Self, Self::Error> {
+        let batch = serde_yaml::from_slice(&batch_file)?;
+        Ok(batch)
+    }
+}
+
+#[derive(Deserialize, Debug, Clone, Default, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub struct Job {
+    pub name: Option<String>,
+    pub on_repositories: Vec<Repository>,
+    pub steps: Vec<Step>,
+}
+
+impl Job {
+    pub async fn run(
+        &self,
+        octocrab: &Octocrab,
+        ctx: &Context<'_>,
+    ) -> Vec<StepResult<command::Response, Error>> {
+        info!(
+            "job: {}",
+            &self.name.clone().unwrap_or("UNAMED".to_string())
+        );
+        let steps = &self.steps;
+        let steps_iter = steps
+            .iter()
+            .map(|step| async move { step.run(octocrab, &ctx.update_from_job(self)).await });
+        futures::future::join_all(steps_iter).await
+    }
+}
+
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+pub struct Repository {
+    pub owner: String,
+    pub name: String,
+}
+
+#[derive(Deserialize, Debug, Clone, Default, PartialEq)]
+pub struct Step {
+    pub name: Option<String>,
+    pub runs: Vec<command::Command>,
+}
+
+type StepResult<Output, Err> = Vec<Vec<Result<Output, Err>>>;
+
+impl Step {
+    pub async fn run(
+        &self,
+        octocrab: &Octocrab,
+        ctx: &Context<'_>,
+    ) -> StepResult<command::Response, Error> {
+        info!(
+            "step: {}",
+            &self.name.clone().unwrap_or("UNAMED".to_string())
+        );
+        let runs = &self.runs;
+        let runs_iter = runs
+            .iter()
+            .map(|command| async move { command.run(octocrab, &ctx.update_from_step(self)).await });
+        futures::future::join_all(runs_iter).await
+    }
+}
+
+pub struct Octomate {
+    octocrab: Arc<Octocrab>,
+}
+
+impl Octomate {
+    pub async fn new(personal_token: impl Into<String>) -> Result<Self, Error> {
+        let octocrab = octocrab::Octocrab::builder()
+            .personal_token(personal_token.into())
+            .build()?;
+        Ok(Self {
+            octocrab: Arc::new(octocrab),
+        })
+    }
+
+    pub async fn run_batch(&self, batch: &Batch) -> BatchResult<command::Response, Error> {
+        batch.run(&self.octocrab).await
+    }
+
+    pub async fn run_batch_from_file(
+        &self,
+        filepath: impl AsRef<Path>,
+    ) -> Result<BatchResult<command::Response, Error>, Error> {
+        let bytes = io::read_file(filepath).await?;
+        let batch = Batch::try_from(bytes.as_slice())?;
+        Ok(self.run_batch(&batch).await)
+    }
+}

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,0 +1,14 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+pub struct Options {
+    #[clap(long, help = "The batch file to run")]
+    pub batch_file: String,
+}
+
+impl Options {
+    pub fn from_cli() -> Self {
+        Options::parse()
+    }
+}


### PR DESCRIPTION
The project was completely refactored to make it easier to maintain. Also Snafu crate was removed in order to limit the number of dependencies of the project.

Snafu is really awesome but I think I don't need it for the moment. It's better to handle error using From trait implementations manually.